### PR TITLE
Use twilio message status 'sent' rather than 'delivered'

### DIFF
--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -206,7 +206,7 @@ class IsaccRecordCreator:
                     if e.url == "http://isacc.app/twilio-message-status":
                         e.valueCode = message_status
 
-        if message_status == 'delivered':
+        if message_status == 'sent':
             c = self.__create_communication_from_request(cr)
             c = Communication(c)
 


### PR DESCRIPTION
use twilio 'sent' status because the 'delivered' status seems to be unreliable (when I tested it, as well as according to Twilio)