### PR TITLE
communicationRequest to communication - add missing fields, sender and note, that need converting

### DIFF
--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -63,7 +63,7 @@ class IsaccRecordCreator:
                     "code": "SMSWRIT"
                 }]
             }],
-            "note":[n.as_json() for n in cr.note] if cr.note else "",
+            "note":[n.as_json() for n in cr.note] if cr.note else None,
             "status": "completed"
         }
 

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -55,6 +55,7 @@ class IsaccRecordCreator:
 
             "payload": [p.as_json() for p in cr.payload],
             "sent": datetime.now().astimezone().isoformat(),
+            "sender": cr.sender,
             "recipient": [r.as_json() for r in cr.recipient],
             "medium": [{
                 "coding": [{
@@ -62,6 +63,7 @@ class IsaccRecordCreator:
                     "code": "SMSWRIT"
                 }]
             }],
+            "note":[n.as_json() for n in cr.note] if cr.note else "",
             "status": "completed"
         }
 


### PR DESCRIPTION
part of https://www.pivotaltracker.com/story/show/185306799
noticed that the fields `sender` (person that sent the message) and `note` (note/comment about the message)  are missing from the `Communication` request generated from the system (See example screenshot of the existing Communication from shared dev instance):
![Existing communication](https://github.com/uwcirg/isacc-messaging-service/assets/12942714/77554c1b-d9b6-4e9f-9749-abba0e2688a7)


I think the issue stems from the code for converting CommunicationRequest to Communication resource:   `sender` and `note` fields of the `CommunicationRequest` resource were not included when converted to `Communication` resource.  
