### PR TITLE
bugfix from PR #21 - convert sender to JSON

### DIFF
--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -55,7 +55,7 @@ class IsaccRecordCreator:
 
             "payload": [p.as_json() for p in cr.payload],
             "sent": datetime.now().astimezone().isoformat(),
-            "sender": cr.sender,
+            "sender": cr.sender.as_json() if cr.sender else None,
             "recipient": [r.as_json() for r in cr.recipient],
             "medium": [{
                 "coding": [{


### PR DESCRIPTION
Followup fix to PR #21 
when converting CommunicationRequest model object to Communication, the [sender](https://github.com/smart-on-fhir/client-py/blob/master/fhirclient/models/communicationrequest.py#L104) field, which is of type dictionary, should be converted to json.