### PR TITLE
CommunicationRequest to Communication - add missing sender & note fields

### DIFF
--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -55,6 +55,7 @@ class IsaccRecordCreator:
 
             "payload": [p.as_json() for p in cr.payload],
             "sent": datetime.now().astimezone().isoformat(),
+            "sender": cr.sender.as_json() if cr.sender else None,
             "recipient": [r.as_json() for r in cr.recipient],
             "medium": [{
                 "coding": [{
@@ -62,6 +63,7 @@ class IsaccRecordCreator:
                     "code": "SMSWRIT"
                 }]
             }],
+            "note": [n.as_json() for n in cr.note] if cr.note else None,
             "status": "completed"
         }
 


### PR DESCRIPTION
part of https://www.pivotaltracker.com/story/show/185306799
add `sender` & `note` fields when converting CommunicationRequest resource to Communication.
also address issue identified from previously reverted PR #21 