### PR TITLE
add additional status logging incl. time when status was last updated

### DIFF
--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -30,8 +30,11 @@ class IsaccTwilioError(Exception):
 
 
 def first_in_bundle(bundle):
-    if bundle['resourceType'] == 'Bundle' and bundle['total'] > 0:
-        return bundle['entry'][0]['resource']
+    if bundle['resourceType'] == 'Bundle':
+        if bundle['total'] > 0:
+            return bundle['entry'][0]['resource']
+        return None
+    return bundle
 
 
 class IsaccRecordCreator:
@@ -74,16 +77,18 @@ class IsaccRecordCreator:
 
         cr = CommunicationRequest(cr)
         if cr.identifier and len([i for i in cr.identifier if i.system == "http://isacc.app/twilio-message-sid"]) > 0:
-            twilio_messages = [i.value for i in cr.identifier if i.system == "http://isacc.app/twilio-message-sid"]
-            isacc_messaging.audit.audit_entry(
-                f"CommunicationRequest already has Twilio SID ",
-                extra={
-                    'CommunicationRequest': cr.id,
-                    "Twilio messages": twilio_messages
-                },
-                level='debug'
-            )
-            return None
+            sid = ""
+            status = ""
+            as_of = ""
+            for i in cr.identifier:
+                for e in i.extension:
+                    if e.url == "http://isacc.app/twilio-message-status":
+                        status = e.valueCode
+                    if e.url == "http://isacc.app/twilio-message-status-updated":
+                        as_of = e.valueDateTime.isostring
+                if i.system == "http://isacc.app/twilio-message-sid":
+                    sid = i.value
+            return f"Twilio message (sid: {sid}) was previously dispatched. Last known status: {status} (as of {as_of})"
 
         target_phone = self.get_caring_contacts_phone_number(cr.recipient[0].reference.split('/')[1])
         try:
@@ -91,7 +96,7 @@ class IsaccRecordCreator:
         except TwilioRestException as ex:
             isacc_messaging.audit.audit_entry(
                 "Twilio exception",
-                extra={"resource": result, "exception": ex},
+                extra={"resource": f"CommunicationResource/{cr.id}", "exception": ex},
                 level='exception'
             )
             raise IsaccTwilioError(f"ERROR! {ex} raised attempting to send SMS")
@@ -109,7 +114,16 @@ class IsaccRecordCreator:
             cr.identifier.append(Identifier({
                 "system": "http://isacc.app/twilio-message-sid",
                 "value": result.sid,
-                "extension": [{"url": "http://isacc.app/twilio-message-status", "valueCode": result.status}]
+                "extension": [
+                    {
+                        "url": "http://isacc.app/twilio-message-status",
+                        "valueCode": result.status
+                    },
+                    {
+                        "url": "http://isacc.app/twilio-message-status-updated",
+                        "valueDateTime": datetime.now().astimezone().isoformat()
+                    },
+                ]
             }))
             updated_cr = HAPI_request('PUT', 'CommunicationRequest', resource_id=cr.id, resource=cr.as_json())
             isacc_messaging.audit.audit_entry(
@@ -118,7 +132,7 @@ class IsaccRecordCreator:
                 level='debug'
             )
 
-            return updated_cr
+            return f"Twilio message dispatched (status={result.status})"
 
     def send_twilio_sms(self, message, to_phone, from_phone=None):
         from twilio.rest import Client
@@ -277,6 +291,8 @@ class IsaccRecordCreator:
                 for e in i.extension:
                     if e.url == "http://isacc.app/twilio-message-status":
                         e.valueCode = message_status
+                    if e.url == "http://isacc.app/twilio-message-status-updated":
+                        e.valueDateTime = FHIRDate(datetime.now().astimezone().isoformat())
 
         # sometimes we go straight to delivered. other times we go to sent and then delivered. sometimes we go to sent
         # and never delivered (it has been delivered but we don't get a callback with that status)
@@ -402,7 +418,7 @@ class IsaccRecordCreator:
             )
         return "routine"
 
-    def execute_requests(self) -> Tuple[List[str], List[dict]]:
+    def execute_requests(self) -> Tuple[List[dict], List[dict]]:
         """
         For all due CommunicationRequests, generate SMS, create Communication resource, and update CommunicationRequest
         """
@@ -434,8 +450,8 @@ class IsaccRecordCreator:
             for entry in result['entry']:
                 cr = entry['resource']
                 try:
-                    self.convert_communicationrequest_to_communication(cr=cr)
-                    successes.append(cr['id'])
+                    status = self.convert_communicationrequest_to_communication(cr=cr)
+                    successes.append({'id': cr['id'], 'status': status})
                 except Exception as e:
                     errors.append({'id': cr['id'], 'error': e})
 

--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -160,16 +160,24 @@ def execute_requests_route():
 def execute_requests():
     successes, errors = IsaccRecordCreator().execute_requests()
 
+    success_list = ""
+    error_list = ""
+
     if len(successes) > 0:
+        success_list = '\n'.join([f"ID: {c['id']}, Status: {c['status']}" for c in successes])
         isacc_messaging.audit.audit_entry(
-            f"Successfully executed CommunicationRequest resources: {', '.join(successes)}",
+            f"Successfully executed CommunicationRequest resources",
+            extra={'successful_resources': success_list},
             level='info'
         )
     if len(errors) > 0:
         error_list = '\n'.join([f"ID: {c['id']}, Error: {c['error']}" for c in errors])
         isacc_messaging.audit.audit_entry(
-            "Execution failed for CommunicationRequest resources:",
+            "Execution failed for CommunicationRequest resources",
             extra={'failed_resources': error_list},
             level='error'
         )
-        return f"Execution failed for CommunicationRequest resources:\n{error_list}"
+    return "\n".join([
+        f"Execution succeeded for CommunicationRequest resources:\n{success_list}",
+        f"Execution failed for CommunicationRequest resources:\n{error_list}"
+    ])


### PR DESCRIPTION
When we send a message dispatch request to Twilio, we expect a `MessageStatus` update when the message was delivered (or failed to deliver). Only when we receive this update is the CommunicationRequest marked as completed.
If Twilio takes its time, the CommunicationRequest might still be outstanding next time the chron job to `execute_requests` is run. In this case, the outstanding CommunicationRequest appears in the search results for overdue CommunicationRequests again, but because Twilio has already been sent a dispatch request, we pass over the message without taking an action -- but we log another "success" event for this CommunicationRequest.
Sometimes Twilio will accept a message dispatch request and return a status of queued, and then never update us again, for whatever reason.
When this happens, the corresponding CommunicationRequest resource will be checked (and trigger an entry in the log output) every time `execute_requests` is called (by the chron job) forever.
It was not apparent from the log what these repeated success log entries mean.
This PR:
- makes the log messages clearer by differentiating between newly dispatched messages and messages that are passed over because they were already dispatched, and adding the last status received from Twilio
- adds a timestamp for when status was last updated by Twilio. In the future, this can be used to handle messages that are stuck in Twilio MessageStatus limbo. One option might be to mark them as failed if we haven't received a status update in 24 hours.