### PR TITLE
PHI out of email; direct link to messaging client

### DIFF
--- a/isacc_messaging/api/email_notifications.py
+++ b/isacc_messaging/api/email_notifications.py
@@ -8,21 +8,21 @@ from flask import current_app
 import isacc_messaging
 
 
-def send_message_received_notification(recipients: list, patient_message, patient_name):
+def send_message_received_notification(recipients: list, patient_id):
     port = current_app.config.get('EMAIL_PORT')  # For SSL
     email_server = current_app.config.get('EMAIL_SERVER')
     email = current_app.config.get('ISACC_NOTIFICATION_EMAIL_SENDER_ADDRESS')
     subject = current_app.config.get('ISACC_NOTIFICATION_EMAIL_SUBJECT', 'New message received')
     app_password = current_app.config.get('ISACC_NOTIFICATION_EMAIL_PASSWORD')
     sender_name = current_app.config.get('ISACC_NOTIFICATION_EMAIL_SENDER_NAME')
-    link_url = current_app.config.get("ISACC_APP_URL")
+    query = f"sof_client_id=MESSAGING&patient={patient_id}"
+    link_url = f'{current_app.config.get("ISACC_APP_URL")}/target?{query}'
     text = f"ISACC received a message.\nGo to {link_url} to view it."
     html = f"""\
         <html>
           <head></head>
           <body>
-            <p>ISACC received a message from {patient_name}:<br><br>
-            {patient_message}
+            <p>ISACC received a patient message.
             <br><br>
                Go to <a href="{link_url}">ISACC</a> to view it.
             </p>

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -195,7 +195,7 @@ class IsaccRecordCreator:
                             emails.append(t.value)
         if not emails:
             isacc_messaging.audit.audit_entry(
-                "no practioner email to notify",
+                "no practitioner email to notify",
                 extra={"Patient": str(pt)},
                 level='warn'
             )
@@ -264,8 +264,7 @@ class IsaccRecordCreator:
         )
         patient = self.get_patient(patient_id)
         notify_emails = self.get_general_practitioner_emails(patient)
-        patient_name = " ".join([f"{' '.join(n.given)} {n.family}" for n in patient.name])
-        send_message_received_notification(notify_emails, message, patient_name)
+        send_message_received_notification(notify_emails, patient_id)
         self.update_followup_extension(patient_id, message_time)
 
     def on_twilio_message_status_update(self, values):


### PR DESCRIPTION
Email notification: remove SMS contents and identifiers; add link to patient record in messaging client.  https://www.pivotaltracker.com/story/show/185260711

NB: this requires pending femr changes for the link to function.