### PR TITLE
Prevent unwanted exceptions from `execute_requests()` calls

### DIFF
--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -142,19 +142,13 @@ def incoming_sms_handler():
 
 @base_blueprint.cli.command("execute_requests")
 def execute_requests_cli():
-    result = execute_requests()
-
-    if result is not None:
-        raise Exception(result)
+    execute_requests()
 
 
 @base_blueprint.route("/execute_requests", methods=['POST'])
 def execute_requests_route():
     result = execute_requests()
-
-    if result is not None:
-        return result, 500
-    return '', 204
+    return str(result), 204
 
 
 def execute_requests():


### PR DESCRIPTION
Both view and cli/cron calls to `execute_requests()` were generating exceptions on expected output.  Don't trap output but share with the view, and allow exceptions to percolate up naturally in exceptional cases.

Prior to this change, since merge of #26, a valid run would produce cron/command line results such as the following, which would trigger unwanted elastalerts:

```
<full stack>
  File "/opt/app/isacc_messaging/api/views.py", line 148, in execute_requests_cli
    raise Exception(result)
Exception: Execution succeeded for CommunicationRequest resources:
ID: 102, Status: Twilio message (sid: SMc1afeac1b795dd1b1f65eca110afa7e4) was previously dispatched. Last known status: queued (as of )
Execution failed for CommunicationRequest resources:
```