### PR TITLE
update code for sending notification email for practitioners

### DIFF
--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -183,6 +183,12 @@ class IsaccRecordCreator:
         emails = []
         care_plan = self.get_careplan(patient_id)
         if care_plan and care_plan.careTeam and len(care_plan.careTeam) > 0:
+            if len(care_plan.careTeam) > 1:
+                isacc_messaging.audit.audit_entry(
+                    "patient has more than one care team",
+                    extra={"Patient": patient_id},
+                    level='warn'
+                )
             # get the referenced CareTeam resource from the care plan
             # please see https://www.pivotaltracker.com/story/show/185407795
             # carePlan.careTeam now includes those that follow the patient
@@ -269,8 +275,7 @@ class IsaccRecordCreator:
             extra={"resource": result},
             level='debug'
         )
-        patient = self.get_patient(patient_id)
-        notify_emails = self.get_practitioners_emails(patient)
+        notify_emails = self.get_practitioners_emails(patient_id)
         send_message_received_notification(notify_emails, patient_id)
         self.update_followup_extension(patient_id, message_time)
 

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -156,24 +156,29 @@ class IsaccRecordCreator:
         if result is not None:
             return Patient(result)
 
-    def get_general_practitioner_emails(self, pt: Patient) -> list:
+    def get_practitioners_emails(self, patient_id) -> list:
         emails = []
-        if pt and pt.generalPractitioner:
-            for gp_ref in pt.generalPractitioner:
-                # format of gp_ref.reference: "Practitioner/2"
-                resource_type, resource_id = gp_ref.reference.split('/')
-                result = HAPI_request('GET', resource_type, resource_id)
-                if result is not None:
-                    if resource_type != 'Practitioner':
-                        raise ValueError(f"expected Practitioner in {gp_ref.reference}")
-                    gp = Practitioner(result)
-                    for t in gp.telecom:
-                        if t.system == 'email':
-                            emails.append(t.value)
+        care_plan = self.get_careplan(patient_id)
+        if care_plan and care_plan.careTeam and len(care_plan.careTeam) > 0:
+            # get the referenced CareTeam resource from the care plan
+            resource_type, resource_id = care_plan.careTeam[0].reference.split('/')
+            care_team = HAPI_request('GET', resource_type, resource_id)
+            if care_team and care_team.participant:
+                # format of participants: [{member: {reference: Practitioner/1}}]
+                for participant in care_team.participant:
+                    # format of member.reference: "Practitioner/2"
+                    resource_type, resource_id = participant.member.reference.split('/')
+                    if resource_type == 'Practitioner':
+                        result = HAPI_request('GET', resource_type, resource_id)
+                        if result is not None:
+                            gp = Practitioner(result)
+                            for t in gp.telecom:
+                                if t.system == 'email':
+                                    emails.append(t.value)
         if not emails:
             isacc_messaging.audit.audit_entry(
                 "no practioner email to notify",
-                extra={"Patient": str(pt)},
+                extra={"Patient": patient_id},
                 level='warn'
             )
         return emails
@@ -240,7 +245,7 @@ class IsaccRecordCreator:
             level='debug'
         )
         patient = self.get_patient(patient_id)
-        notify_emails = self.get_general_practitioner_emails(patient)
+        notify_emails = self.get_practitioners_emails(patient_id)
         patient_name = " ".join([f"{' '.join(n.given)} {n.family}" for n in patient.name])
         send_message_received_notification(notify_emails, message, patient_name)
         self.update_followup_extension(patient_id, message_time)

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -194,7 +194,7 @@ class IsaccRecordCreator:
             # carePlan.careTeam now includes those that follow the patient
             resource_type, resource_id = care_plan.careTeam[0].reference.split('/')
             care_team = HAPI_request('GET', resource_type, resource_id)
-            if care_team and care_team.participant:
+            if care_team is not None and care_team.participant is not None:
                 # format of participants: [{member: {reference: Practitioner/1}}]
                 for participant in care_team.participant:
                     # format of member.reference: "Practitioner/2"

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -184,6 +184,8 @@ class IsaccRecordCreator:
         care_plan = self.get_careplan(patient_id)
         if care_plan and care_plan.careTeam and len(care_plan.careTeam) > 0:
             # get the referenced CareTeam resource from the care plan
+            # please see https://www.pivotaltracker.com/story/show/185407795
+            # carePlan.careTeam now includes those that follow the patient
             resource_type, resource_id = care_plan.careTeam[0].reference.split('/')
             care_team = HAPI_request('GET', resource_type, resource_id)
             if care_team and care_team.participant:

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -194,11 +194,11 @@ class IsaccRecordCreator:
             # carePlan.careTeam now includes those that follow the patient
             resource_type, resource_id = care_plan.careTeam[0].reference.split('/')
             care_team = HAPI_request('GET', resource_type, resource_id)
-            if care_team is not None and care_team.participant is not None:
+            if care_team and care_team.get('participant'):
                 # format of participants: [{member: {reference: Practitioner/1}}]
-                for participant in care_team.participant:
+                for participant in care_team['participant']:
                     # format of member.reference: "Practitioner/2"
-                    resource_type, resource_id = participant.member.reference.split('/')
+                    resource_type, resource_id = participant['member']['reference'].split('/')
                     if resource_type == 'Practitioner':
                         result = HAPI_request('GET', resource_type, resource_id)
                         if result is not None:
@@ -213,7 +213,7 @@ class IsaccRecordCreator:
                 level='warn'
             )
         return emails
-    
+
     def get_general_practitioner_emails(self, pt: Patient) -> list:
         emails = []
         if pt and pt.generalPractitioner:
@@ -417,7 +417,7 @@ class IsaccRecordCreator:
 
     def on_twilio_message_received(self, values):
         pt = HAPI_request('GET', 'Patient', params={
-            'telecom': values.get('From').replace("+1", "")
+            'telecom': values.get('From', "+1").replace("+1", "")
         })
         pt = first_in_bundle(pt)
         if not pt:

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -202,7 +202,7 @@ class IsaccRecordCreator:
                                     emails.append(t.value)
         if not emails:
             isacc_messaging.audit.audit_entry(
-                "no practioner email to notify",
+                "no practitioner email to notify",
                 extra={"Patient": patient_id},
                 level='warn'
             )


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185407795
see [PR](https://github.com/uwcirg/isacc-messaging-client-sof/pull/55)
Patient's followers are now referenced on the `CareTeam` resource, referenced by the patient's `CarePlan`
hence the code for sending out emails to notify practitioners needs to be updated as well
