### PR TITLE
Feature/resolve reference

### DIFF
--- a/isacc_messaging/api/fhir.py
+++ b/isacc_messaging/api/fhir.py
@@ -1,7 +1,32 @@
 from flask import current_app
 import requests
 
+from fhirclient.models.patient import Patient
+from fhirclient.models.practitioner import Practitioner
 from isacc_messaging.audit import audit_entry
+
+
+def resovlve_reference(reference_string):
+    """FHIRClient includes a `resolved()` method, but has yet to implement
+
+    :param reference_string: i.e. "Patient/2"
+    :return: instantiated FHIRClient instance by fetching resource
+    """
+    # expand supported class list as needed
+    supported_classes = (Patient, Practitioner)
+    resource_type, id = reference_string.split('/')
+    klass = None
+    for c in supported_classes:
+        if resource_type == klass.resource_type:
+            klass = c
+            break
+    if klass is None:
+        raise ValueError("resource_type: {resource_type} not in supported")
+
+    result = HAPI_request('GET', resource_type, resource_id=id)
+    if result is not None:
+        return klass(result)
+    raise IsaccNotFoundError("{reference_string} NOT FOUND")
 
 
 def HAPI_request(

--- a/isacc_messaging/api/fhir.py
+++ b/isacc_messaging/api/fhir.py
@@ -7,6 +7,11 @@ from fhirclient.models.practitioner import Practitioner
 from isacc_messaging.audit import audit_entry
 
 
+class IsaccNotFoundError(Exception):
+    """Raised when an expected resource lookup fails"""
+    pass
+
+
 def resolve_reference(reference_string):
     """FHIRClient includes a `resolved()` method, but has yet to implement
 

--- a/isacc_messaging/api/fhir.py
+++ b/isacc_messaging/api/fhir.py
@@ -1,25 +1,26 @@
 from flask import current_app
 import requests
 
+from fhirclient.models.careteam import CareTeam
 from fhirclient.models.patient import Patient
 from fhirclient.models.practitioner import Practitioner
 from isacc_messaging.audit import audit_entry
 
 
-def resovlve_reference(reference_string):
+def resolve_reference(reference_string):
     """FHIRClient includes a `resolved()` method, but has yet to implement
 
     :param reference_string: i.e. "Patient/2"
     :return: instantiated FHIRClient instance by fetching resource
     """
     # expand supported class list as needed
-    supported_classes = (Patient, Practitioner)
+    supported_classes = {
+        "CareTeam": CareTeam,
+        "Patient": Patient,
+        "Practitioner": Practitioner,
+    }
     resource_type, id = reference_string.split('/')
-    klass = None
-    for c in supported_classes:
-        if resource_type == klass.resource_type:
-            klass = c
-            break
+    klass = supported_classes.get(resource_type)
     if klass is None:
         raise ValueError("resource_type: {resource_type} not in supported")
 

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -9,7 +9,6 @@ from fhirclient.models.fhirdate import FHIRDate
 from fhirclient.models.identifier import Identifier
 from fhirclient.models.patient import Patient
 from fhirclient.models.extension import Extension
-from fhirclient.models.practitioner import Practitioner
 from flask import current_app
 from twilio.base.exceptions import TwilioRestException
 
@@ -26,11 +25,6 @@ class IsaccFhirException(Exception):
 
 class IsaccTwilioError(Exception):
     """Raised when Twilio SMS are not functioning as required for ISACC"""
-    pass
-
-
-class IsaccNotFoundError(Exception):
-    """Raised when an expected resource lookup failes"""
     pass
 
 


### PR DESCRIPTION
FHIRClient includes a `resolved()` method, but the implementation (even in latest) does not include what we generally need - to obtain the referenced resource by absolute path.

Added a generalized `fhir.resolve_reference()` method and cleaned up the many code blocks doing this in a variety of ways.

Also eliminated a number of round trips for the same `patient` by passing the instance rather than by `id` only to look it up, again.