### PR TITLE
CommunicationRequest.recipient is a list - corret bug.

### DIFF
--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -377,7 +377,7 @@ class IsaccRecordCreator:
                 )
                 # if this was a manual message, mark patient as having been followed up with
                 if self.is_manual_follow_up_message(c):
-                    self.mark_patient_followed_up(resolve_reference(cr.recipient.reference))
+                    self.mark_patient_followed_up(resolve_reference(cr.recipient[0].reference))
             else:
                 isacc_messaging.audit.audit_entry(
                     f"Received /MessageStatus callback with status {message_status} on existing Communication resource",


### PR DESCRIPTION
Thanks to error on prod helping us locate, corrected CommunicationRequest.recipient access to use first item in list, like all other usage in module.

Stack from prod:
```
  File "/opt/app/isacc_messaging/api/isacc_record_creator.py", line 380, in on_twilio_message_status_update
    self.mark_patient_followed_up(resolve_reference(cr.recipient.reference))
AttributeError: 'list' object has no attribute 'reference'
```

the scenario we didn't test is a manual message response from a practitioner, this error would not only create a 500 for twilio but also prevent the update to the ```time-of-last-unfollowedup-message```