### PR TITLE
Cutoff date of 48 hours back, for looking up CommunicationRequests 

### DIFF
--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -490,10 +490,14 @@ class IsaccRecordCreator:
         errors = []
 
         limit = 200
+        now = datetime.now()
+        cutoff = now - timedelta(days=2)
+
         result = HAPI_request('GET', 'CommunicationRequest', params={
             "category": "isacc-scheduled-message,isacc-manually-sent-message",
             "status": "active",
-            "occurrence": f"le{datetime.now().astimezone().isoformat()}",
+            "occurrence": f"le{now.astimezone().isoformat()}",
+            "occurrence": f"gt{cutoff.astimezone().isoformat()}",
             "_count": str(limit)
         })
 


### PR DESCRIPTION
As per https://www.pivotaltracker.com/story/show/186171864 - now including a `cutoff` date when looking for outstanding CommunicationRequests to send.