### PR TITLE
maintain next outgoing extension on patients

### DIFF
--- a/isacc_messaging/api/fhir.py
+++ b/isacc_messaging/api/fhir.py
@@ -3,10 +3,10 @@ import requests
 from urllib.parse import parse_qs, urlsplit
 
 from fhirclient.models.careteam import CareTeam
-from fhirclient.models.patient import Patient
 from fhirclient.models.practitioner import Practitioner
 from isacc_messaging.audit import audit_entry
 
+from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
 
 class IsaccNotFoundError(Exception):
     """Raised when an expected resource lookup fails"""

--- a/isacc_messaging/api/fhir.py
+++ b/isacc_messaging/api/fhir.py
@@ -2,11 +2,8 @@ from flask import current_app
 import requests
 from urllib.parse import parse_qs, urlsplit
 
-from fhirclient.models.careteam import CareTeam
-from fhirclient.models.practitioner import Practitioner
 from isacc_messaging.audit import audit_entry
 
-from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
 
 class IsaccNotFoundError(Exception):
     """Raised when an expected resource lookup fails"""
@@ -19,6 +16,10 @@ def resolve_reference(reference_string):
     :param reference_string: i.e. "Patient/2"
     :return: instantiated FHIRClient instance by fetching resource
     """
+    from fhirclient.models.careteam import CareTeam
+    from fhirclient.models.practitioner import Practitioner
+    from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
+
     # expand supported class list as needed
     supported_classes = {
         "CareTeam": CareTeam,

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -116,6 +116,10 @@ class IsaccRecordCreator:
                 patient=patient,
                 practitioner=practitioner)
             result = self.send_twilio_sms(message=expanded_payload, to_phone=target_phone)
+            # maintain next outgoing extension after each send
+            patient.mark_next_outgoing()
+            patient.persist()
+
         except TwilioRestException as ex:
             isacc_messaging.audit.audit_entry(
                 "Twilio exception",

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -7,9 +7,7 @@ from fhirclient.models.communication import Communication
 from fhirclient.models.communicationrequest import CommunicationRequest
 from fhirclient.models.fhirdate import FHIRDate
 from fhirclient.models.identifier import Identifier
-from fhirclient.models.patient import Patient
 from fhirclient.models.practitioner import Practitioner
-from fhirclient.models.extension import Extension
 from flask import current_app
 from twilio.base.exceptions import TwilioRestException
 
@@ -22,6 +20,7 @@ from isacc_messaging.api.fhir import (
     resolve_reference,
 )
 from isacc_messaging.api.ml_utils import predict_score
+from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
 
 
 def expand_template_args(content: str, patient: Patient, practitioner: Practitioner) -> str:
@@ -402,11 +401,7 @@ class IsaccRecordCreator:
           response to the patient.
         """
         followup_system = "http://isacc.app/time-of-last-unfollowedup-message"
-        if patient.extension is None:
-            patient.extension = []
-
-        matching_extensions = [i for i in patient.extension if i.url == followup_system]
-        patient.extension = [i for i in patient.extension if i.url != followup_system]
+        existing = patient.get_extension(url=followup_system, accessor="valueDateTime")
 
         if value_date_time is None:
             # Set to 50 years in the future for patient sort by functionality
@@ -414,12 +409,9 @@ class IsaccRecordCreator:
         else:
             # If older value exists, prefer
             given_value = FHIRDate(value_date_time)
-            existing = [i.valueDateTime for i in matching_extensions]
-            save_value = min(given_value, *existing, key=lambda x: x.date) if existing else given_value
-        patient.extension.append(Extension({
-                "url": followup_system,
-                "valueDateTime": save_value.isostring
-            }))
+            save_value = min(given_value, existing, key=lambda x: x.date) if existing else given_value
+
+        patient.set_extension(url=followup_system, value=save_value.isostring, attribute="valueDateTime")
 
         result = HAPI_request('PUT', 'Patient', resource_id=patient.id, resource=patient.as_json())
         isacc_messaging.audit.audit_entry(

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -4,7 +4,6 @@ from typing import List, Tuple
 
 from fhirclient.models.careplan import CarePlan
 from fhirclient.models.communication import Communication
-from fhirclient.models.communicationrequest import CommunicationRequest
 from fhirclient.models.fhirdate import FHIRDate
 from fhirclient.models.identifier import Identifier
 from fhirclient.models.practitioner import Practitioner
@@ -20,6 +19,7 @@ from isacc_messaging.api.fhir import (
     resolve_reference,
 )
 from isacc_messaging.api.ml_utils import predict_score
+from isacc_messaging.models.isacc_communicationrequest import IsaccCommunicationRequest as CommunicationRequest
 from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
 
 

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -116,7 +116,7 @@ class IsaccRecordCreator:
                 patient=patient,
                 practitioner=practitioner)
             result = self.send_twilio_sms(message=expanded_payload, to_phone=target_phone)
-            # maintain next outgoing extension after each send
+            # maintain next outgoing Twilio message extension after each send
             patient.mark_next_outgoing()
             patient.persist()
 

--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -184,7 +184,8 @@ def update_next_outgoing_extension(simulate=True):
     from isacc_messaging.api.fhir import next_in_bundle
     from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
     active_patients = Patient.active_patients()
-    for patient in next_in_bundle(active_patients):
+    for json_patient in next_in_bundle(active_patients):
+        patient = Patient(json_patient)
         patient.mark_next_outgoing(verbosity=3)
         if not simulate:
             patient.persist()

--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -178,7 +178,7 @@ def execute_requests():
 
 
 @base_blueprint.cli.command("maintenance-update-next-outgoing")
-@click.option("--simulate", is_flag=True, default=False, help="Simulate execution; don't persist to FHIR store")
+@click.option("--dry-run", is_flag=True, default=False, help="Simulate execution; don't persist to FHIR store", simulate)
 def update_next_outgoing_extension(simulate=True):
     """Iterate through active patients, update any stale/missing next-outgoing identifiers"""
     from isacc_messaging.api.fhir import next_in_bundle

--- a/isacc_messaging/models/isacc_communicationrequest.py
+++ b/isacc_messaging/models/isacc_communicationrequest.py
@@ -23,5 +23,4 @@ class IsaccCommunicationRequest(CommunicationRequest):
             "_sort": "occurrence",
             "_maxresults": 1
         })
-        response.raise_for_status()
         return first_in_bundle(response)

--- a/isacc_messaging/models/isacc_communicationrequest.py
+++ b/isacc_messaging/models/isacc_communicationrequest.py
@@ -19,8 +19,10 @@ class IsaccCommunicationRequest(CommunicationRequest):
         response = HAPI_request('GET', 'CommunicationRequest', params={
             "category": "isacc-scheduled-message,isacc-manually-sent-message",
             "status": "active",
-            "subject": f"Patient/{patient.id}",
+            "recipient": f"Patient/{patient.id}",
             "_sort": "occurrence",
             "_maxresults": 1
         })
-        return first_in_bundle(response)
+        first = first_in_bundle(response)
+        if first:
+            return CommunicationRequest(first)

--- a/isacc_messaging/models/isacc_communicationrequest.py
+++ b/isacc_messaging/models/isacc_communicationrequest.py
@@ -18,7 +18,7 @@ class IsaccCommunicationRequest(CommunicationRequest):
         """Lookup next active CommunicationRequest for given patient"""
         response = HAPI_request('GET', 'CommunicationRequest', params={
             "category": "isacc-scheduled-message,isacc-manually-sent-message",
-            "status": "active",
+            "active": True,
             "subject": f"Patient/{patient.id}",
             "_sort": "occurrence",
             "_maxresults": 1

--- a/isacc_messaging/models/isacc_communicationrequest.py
+++ b/isacc_messaging/models/isacc_communicationrequest.py
@@ -1,0 +1,27 @@
+"""ISACC CommunicationRequest Module
+
+Captures common methods needed by ISACC for CommunicationRequests, by specializing
+the `fhirclient.CommunicationRequest` class.
+"""
+from fhirclient.models.communicationrequest import CommunicationRequest
+
+from isacc_messaging.api.fhir import HAPI_request, first_in_bundle
+
+
+class IsaccCommunicationRequest(CommunicationRequest):
+
+    def __init__(self, jsondict=None, strict=True):
+        super(IsaccCommunicationRequest, self).__init__(jsondict=jsondict, strict=strict)
+
+    @staticmethod
+    def next_by_patient(patient):
+        """Lookup next active CommunicationRequest for given patient"""
+        response = HAPI_request('GET', 'CommunicationRequest', params={
+            "category": "isacc-scheduled-message,isacc-manually-sent-message",
+            "status": "active",
+            "subject": f"Patient/{patient.id}",
+            "_sort": "occurrence",
+            "_maxresults": 1
+        })
+        response.raise_for_status()
+        return first_in_bundle(response)

--- a/isacc_messaging/models/isacc_communicationrequest.py
+++ b/isacc_messaging/models/isacc_communicationrequest.py
@@ -18,7 +18,7 @@ class IsaccCommunicationRequest(CommunicationRequest):
         """Lookup next active CommunicationRequest for given patient"""
         response = HAPI_request('GET', 'CommunicationRequest', params={
             "category": "isacc-scheduled-message,isacc-manually-sent-message",
-            "active": True,
+            "status": "active",
             "subject": f"Patient/{patient.id}",
             "_sort": "occurrence",
             "_maxresults": 1

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -78,12 +78,14 @@ class IsaccPatient(Patient):
         This method calculates and updates the identifier
         """
         from isacc_messaging.models.isacc_communicationrequest import IsaccCommunicationRequest as CommunicationRequest
-        next_outgoing_time = CommunicationRequest.next_by_patient(self)
+        next_outgoing = CommunicationRequest.next_by_patient(self)
 
         # without any pending outgoing messages, add a bogus value
         # 50 years ago, to keep the patient in the search
-        if not next_outgoing_time:
+        if not next_outgoing:
             next_outgoing_time = FHIRDate((datetime.now().astimezone() - timedelta(days=50*365.25)).isoformat())
+        else:
+            next_outgoing_time = next_outgoing.occurrenceDateTime
 
         if verbosity > 0:
             logging.info(f"Patient {self.id} next outgoing: {next_outgoing_time.isostring}")

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -42,10 +42,7 @@ class IsaccPatient(Patient):
 
         for extension in self.extension:
             if extension.url == url:
-                value = getattr(extension, attribute)()
-                if attribute == "valueDateTime":
-                    return FHIRDate(value)
-                return value
+                return getattr(extension, attribute)
 
     def set_extension(self, url, value, attribute):
         """Set value for extension on patient to given value.
@@ -93,7 +90,7 @@ class IsaccPatient(Patient):
         url = "http://isacc.app/date-time-of-next-outgoing-message"
         if verbosity > 1:
             current_value = self.get_extension(url=url, attribute="valueDateTime")
-            logging.info(f"current identifier value {current_value}")
+            logging.info(f"current identifier value {current_value.isostring}")
         self.set_extension(url=url, value=next_outgoing_time.isostring, attribute="valueDateTime")
 
     def persist(self):
@@ -103,5 +100,4 @@ class IsaccPatient(Patient):
             resource_type=self.resource_type,
             resource_id=self.id,
             resource=self.as_json())
-        response.raise_for_status()
-        return response.json()
+        return response

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -90,7 +90,8 @@ class IsaccPatient(Patient):
         url = "http://isacc.app/date-time-of-next-outgoing-message"
         if verbosity > 1:
             current_value = self.get_extension(url=url, attribute="valueDateTime")
-            logging.info(f"current identifier value {current_value.isostring}")
+            cv = current_value.isostring if current_value else None
+            logging.info(f"current identifier value {cv}")
         self.set_extension(url=url, value=next_outgoing_time.isostring, attribute="valueDateTime")
 
     def persist(self):

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -18,10 +18,12 @@ class IsaccPatient(Patient):
 
     @staticmethod
     def active_patients():
-        """Execute query for active patients"""
-        response = HAPI_request('GET', 'Patient', params={
-            "active": True,
-        })
+        """Execute query for active patients
+
+        NB, until status is set on all patients, queries for
+        any status/active value will skip those without a value.
+        """
+        response = HAPI_request('GET', 'Patient')
         return response
 
     def get_extension(self, url, attribute):

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -22,7 +22,6 @@ class IsaccPatient(Patient):
         response = HAPI_request('GET', 'Patient', params={
             "active": True,
         })
-        response.raise_for_status()
         return response
 
     def get_extension(self, url, attribute):

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -77,7 +77,7 @@ class IsaccPatient(Patient):
 
         This method calculates and updates the identifier
         """
-        from isacc_communicationrequest import IsaccCommunicationRequest as CommunicationRequest
+        from isacc_messaging.models.isacc_communicationrequest import IsaccCommunicationRequest as CommunicationRequest
         next_outgoing_time = CommunicationRequest.next_by_patient(self)
 
         # without any pending outgoing messages, add a bogus value
@@ -86,13 +86,13 @@ class IsaccPatient(Patient):
             next_outgoing_time = FHIRDate((datetime.now().astimezone() - timedelta(days=50*365.25)).isoformat())
 
         if verbosity > 0:
-            logging.info(f"Patient {self.id} next outgoing: {next_outgoing_time}")
+            logging.info(f"Patient {self.id} next outgoing: {next_outgoing_time.isostring}")
 
         url = "http://isacc.app/date-time-of-next-outgoing-message"
         if verbosity > 1:
             current_value = self.get_extension(url=url, attribute="valueDateTime")
             logging.info(f"current identifier value {current_value}")
-        self.set_extension(url=url, value=next_outgoing_time, attribute="valueDateTime")
+        self.set_extension(url=url, value=next_outgoing_time.isostring, attribute="valueDateTime")
 
     def persist(self):
         """Persist self state to FHIR store"""

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -20,7 +20,7 @@ class IsaccPatient(Patient):
     def active_patients():
         """Execute query for active patients"""
         response = HAPI_request('GET', 'Patient', params={
-            "status": "active",
+            "active": True,
         })
         response.raise_for_status()
         return response

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -1,0 +1,75 @@
+"""ISACC Patient Module
+
+Captures specialized methods needed by ISACC for Patients, not to be confused with the `fhirclient.Patient` class.
+"""
+from datetime import datetime, timedelta
+
+from fhirclient.models.extension import Extension
+from fhirclient.models.fhirdate import FHIRDate
+from fhirclient.models.patient import Patient
+
+
+class IsaccPatient(Patient):
+
+    def __init__(self, jsondict=None, strict=True):
+        super(IsaccPatient, self).__init__(jsondict=jsondict, strict=strict)
+
+    def get_extension(self, url, attribute):
+        """Get current value for extension of given url, or None if not found
+
+        :param url: like a system on a code, used to identify meaning of the extension
+        :param attribute: as FHIR names different attributes depending on data type, name
+          attribute to use, i.e. "valueDateTime" or "valueInt"
+
+        FHIR includes an [extensibility](http://hl7.org/fhir/R4/extensibility.html) framework
+        for most resources.  This method will return the current value to an extension on the
+        Patient resource, with the matching url, or None if not found.
+        """
+        if not self.extension:
+            return
+
+        for extension in self.extension:
+            if extension.url == url:
+                value = getattr(extension, attribute)()
+                if attribute == "valueDateTime":
+                    return FHIRDate(value)
+                return value
+
+    def set_extension(self, url, value, attribute):
+        """Set value for extension on patient to given value.
+
+        :param url: like a system on a code, used to identify meaning of the extension
+        :param value: value, of datatype expected for named attribute, to set
+        :param attribute: as FHIR names different attributes depending on data type, name
+          attribute to use, i.e. "valueDateTime" or "valueInt"
+
+        FHIR includes an [extensibility](http://hl7.org/fhir/R4/extensibility.html) framework
+        for most resources.  This method will add an extension to the Patient
+        or set the value, such that only a single extension of the given
+        url exists at any time.
+        """
+        if self.extension is None:
+            self.extension = []
+        j = 0
+        for j, extension in zip(range(0, len(self.extension)), self.extension):
+            if extension.url == url:
+                # properties won't allow assignment.  pop the old extension and replace
+                del self.extension[j]
+                break
+        self.extension.append(Extension({"url": url, attribute: value}))
+
+    def mark_next_outgoing(self):
+        """Patient's get a special identifier for time of next outgoing message
+
+        This method calculates and updates the identifier
+        """
+        next_outgoing_time = self._lookup_next_outgoing()
+
+        # without any pending outgoing messages, add a bogus value
+        # 50 years ago, to keep the patient in the search
+        if not next_outgoing_time:
+            next_outgoing_time = FHIRDate((datetime.now().astimezone() - timedelta(days=50*365.25)).isoformat())
+
+        url = "http://isacc.app/date-time-of-next-outgoing-message"
+        self.set_extension(url=url, value=next_outgoing_time, attribute="valueDateTime")
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 from pytest import fixture
-
+from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
 
 @fixture
 def app():
@@ -11,3 +11,9 @@ def app():
 def client(app):
     with app.test_client() as c:
         yield c
+
+
+@fixture
+def patient():
+    p = Patient()
+    return p

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 from pytest import fixture
-from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
 
 @fixture
 def app():
@@ -15,5 +14,6 @@ def client(app):
 
 @fixture
 def patient():
+    from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
     p = Patient()
     return p

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta
+from fhirclient.models.fhirdate import FHIRDate
+
+
+def test_patient_datetime_extension(patient):
+    url = "http://example.com/datetime"
+    value = FHIRDate(datetime.now().isoformat())
+    patient.set_extension(url=url, value=value.isostring, attribute="valueDateTime")
+    assert len(patient.extension) == 1
+    assert patient.extension[0].url == url
+    assert patient.extension[0].valueDateTime.isostring == value.isostring
+
+
+def test_patient_add_extension(patient):
+    url = "http://example.com/no-dups"
+    value = datetime.now().isoformat()
+
+    patient.set_extension(url=url, value=value, attribute="valueDateTime")
+    assert len(patient.extension) == 1
+    assert patient.extension[0].url == url
+    assert patient.extension[0].valueDateTime.origval == value
+
+    # confirm second add with same url replaces first value
+    tomorrow = (datetime.now() + timedelta(days=1)).isoformat()
+
+    patient.set_extension(url=url, value=tomorrow, attribute="valueDateTime")
+    assert len(patient.extension) == 1
+    assert patient.extension[0].url == url
+    assert patient.extension[0].valueDateTime.origval == tomorrow
+
+
+def test_patient_multiple_extensions(patient):
+    url1 = "http://example.com/1"
+    val1 = 10
+
+    url2 = "http://example.com/2"
+    val2 = "5 units"
+
+    patient.set_extension(url=url1, value=val1, attribute="valueInteger")
+    patient.set_extension(url=url2, value=val2, attribute="valueString")
+
+    assert len(patient.extension) == 2
+
+    first = [i for i in patient.extension if i.url == url1]
+    assert len(first) == 1
+    assert first[0].valueInteger == val1
+
+    second = [i for i in patient.extension if i.url == url2]
+    assert len(second) == 1
+    assert second[0].valueString == val2


### PR DESCRIPTION
implementation for  https://www.pivotaltracker.com/story/show/185952917

The messaging service now maintains the Patient extension url:`http://isacc.app/date-time-of-next-outgoing-message` with a `valueDateTime` of the next scheduled outgoing CommunicationRequest for every patient.

As this extension didn't previously exist, and we don't yet have a migration framework, the included CLI entry point must be called after deploying this PR:
```
dc exec messagingservice flask maintenance-update-next-outgoing
```