### PR TITLE
exclude messages more than 48 hours stale

### DIFF
--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -480,7 +480,7 @@ class IsaccRecordCreator:
         errors = []
 
         now = datetime.now()
-        cutoff = now - timedelta(days=2)
+        cutoff = FHIRDate((now - timedelta(days=2)).isoformat())
 
         result = HAPI_request('GET', 'CommunicationRequest', params={
             "category": "isacc-scheduled-message,isacc-manually-sent-message",

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -480,7 +480,7 @@ class IsaccRecordCreator:
         errors = []
 
         now = datetime.now()
-        cutoff = FHIRDate((now - timedelta(days=2)).isoformat())
+        cutoff = now - timedelta(days=2)
 
         result = HAPI_request('GET', 'CommunicationRequest', params={
             "category": "isacc-scheduled-message,isacc-manually-sent-message",
@@ -490,7 +490,7 @@ class IsaccRecordCreator:
 
         for cr_json in next_in_bundle(result):
             cr = CommunicationRequest(cr_json)
-            if cr.occurrenceDateTime < cutoff:
+            if cr.occurrenceDateTime.date < cutoff:
                 # skip over any messages more than 48 hours old, as per #186175825
                 continue
             self.process_cr(errors, cr, successes)

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -492,10 +492,12 @@ class IsaccRecordCreator:
             "category": "isacc-scheduled-message,isacc-manually-sent-message",
             "status": "active",
             "occurrence": f"le{now.astimezone().isoformat()}",
-            "occurrence": f"gt{cutoff.astimezone().isoformat()}",
         })
 
         for cr in next_in_bundle(result):
+            if cr.occurrenceDateTime < cutoff:
+                # skip over any messages more than 48 hours old, as per #186175825
+                continue
             self.process_cr(errors, cr, successes)
 
         return successes, errors

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -479,13 +479,13 @@ class IsaccRecordCreator:
         successes = []
         errors = []
 
-        now = datetime.now()
+        now = datetime.now().astimezone()
         cutoff = now - timedelta(days=2)
 
         result = HAPI_request('GET', 'CommunicationRequest', params={
             "category": "isacc-scheduled-message,isacc-manually-sent-message",
             "status": "active",
-            "occurrence": f"le{now.astimezone().isoformat()}",
+            "occurrence": f"le{now.isoformat()}",
         })
 
         for cr_json in next_in_bundle(result):


### PR DESCRIPTION
Fix for https://www.pivotaltracker.com/story/show/186175825

NB - this replaces PR #44 - as it was found to not work on all versions of HAPI.

Query for CommunicationRequests to process again only looks at occurrence dates prior to now, after discovering the logical AND (by including `occurrence` 2x in the parameters) didn't work.

Toss out any older than the 48 hour cutoff date prior to sending.

(cleaned up passing of CommunicationRequest as object to avoid redundant round trips, etc.)