### PR TITLE
Implement #186296137, daily email to users with count of outgoing

### DIFF
--- a/isacc_messaging/api/email_notifications.py
+++ b/isacc_messaging/api/email_notifications.py
@@ -124,7 +124,6 @@ def generate_outgoing_counts_emails(dry_run, include_test_patients):
                 continue
 
             next_outgoing = p.get_extension(NEXT_OUTGOING_URL, attribute="valueDateTime")
-            logging.info(f"{p.id} {len(patients)}")
             if next_outgoing and next_outgoing.date > now and next_outgoing.date < cutoff:
                 keepers.add(p)
                 known_keepers.add(p)

--- a/isacc_messaging/api/email_notifications.py
+++ b/isacc_messaging/api/email_notifications.py
@@ -7,7 +7,11 @@ from flask import current_app
 
 from isacc_messaging.models.email import send_email
 from isacc_messaging.models.fhir import next_in_bundle
-from isacc_messaging.models.isacc_patient import IsaccPatient as Patient, LAST_UNFOLLOWEDUP_URL
+from isacc_messaging.models.isacc_patient import (
+    IsaccPatient as Patient,
+    LAST_UNFOLLOWEDUP_URL,
+    NEXT_OUTGOING_URL,
+)
 from isacc_messaging.models.isacc_practitioner import IsaccPractitioner as Practitioner
 
 html_template = """
@@ -52,6 +56,109 @@ def send_message_received_notification(recipients: list, patient: Patient):
         text=text,
         html=html,
     )
+
+
+def assemble_outgoing_counts_email(practitioner, patients):
+    """Pull together email content for given practitioner and their list of patients
+
+    :param practitioner: Practitioner object, target of email
+    :param patients: list of Patient objects for whom the practitioner is assigned,
+      expected to only include those with an outgoing message in the next 24 hours
+    :return: email content
+    """
+    SUPPORT_EMAIL = current_app.config.get('ISACC_SUPPORT_EMAIL')
+    UNSUB_LINK = f'{current_app.config.get("ISACC_APP_URL")}/unsubscribe'
+    patient_list_url = f'{current_app.config.get("ISACC_APP_URL")}/home?sort_by=next_message&sort_direction=desc&flags=following'
+    primary, secondary = [], []
+    for p in patients:
+        if p.generalPractitioner and p.generalPractitioner[0].reference == f"Practitioner/{practitioner.id}":
+            primary.append(p)
+            continue
+        secondary.append(p)
+
+    subject = f"ISACC {len(patients)} Caring Contact sending today"
+    contents = []
+    if primary:
+        contents.append(f"Caring Contact messages will be sent to {len(patients)} of your recipients today.")
+    if secondary:
+        contents.append(f"{len(primary)} of those contacts for whom you are the primary author,")
+        contents.append(f"{len(secondary)} of those contacts for whom you are the secondary author.")
+    msg = " ".join(contents)
+    contents.append(f"Click here {patient_list_url} to view which of your recipients will be receiving a message.")
+    contents.append("If you are not the person who should be getting these messages, contact your site lead.")
+    html = html_template.format(
+        pre_link_msg=msg,
+        link_url=patient_list_url,
+        link_suffix_text="to view which of your recipients will be receiving a message.",
+        post_link_msg=(
+            "If you are not the person who should be getting these messages, contact "
+            f'<a href="mailto:{SUPPORT_EMAIL}">your site lead</a>.'),
+        unsubscribe_link=UNSUB_LINK)
+
+    return {
+        "subject": subject,
+        "text": " ".join(contents),
+        "html": html}
+
+
+
+
+def generate_outgoing_counts_emails(dry_run):
+    """Generate system emails to practitioners with counts
+
+    :param dry_run: set true to generate but not send email
+
+    At a scheduled time every day, this function will be triggered to generate email
+    for every practitioner in the system, detailing the number of patients for which
+    they have outgoing texts in the next 24 hours.
+    """
+    cutoff = datetime.now().astimezone() + timedelta(days=1)
+    known_keepers = []
+    known_skippers = []
+
+    def outgoing_patients(patients):
+        """helper to return only sublist of patients with qualified outgoing messages"""
+        keepers = []
+        for p in patients:
+            if p in known_keepers:
+                keepers.append(p)
+                continue
+            if p in known_skippers:
+                continue
+
+            next_outgoing = p.get_extension(NEXT_OUTGOING_URL, attribute="valueDateTime")
+            if next_outgoing and next_outgoing.date < cutoff:
+                keepers.append(p)
+                known_keepers.append(p)
+            else:
+                known_skippers.append(p)
+
+        return keepers
+
+    practitioners = Practitioner.active_practitioners()
+    for p in next_in_bundle(practitioners):
+        practitioner = Practitioner(p)
+        practitioners_patients = practitioner.practitioner_patients()
+        outgoing = outgoing_patients(practitioners_patients)
+        if not outgoing:
+            logging.debug(f"no qualifying outgoing patients for {practitioner}")
+            continue
+
+        email_bits = assemble_outgoing_counts_email(practitioner, outgoing)
+        if not dry_run:
+            send_email(
+                recipient_emails=[practitioner.email_address],
+                subject=email_bits["subject"],
+                html=email_bits["html"],
+                text=email_bits["text"])
+        else:
+            click.echo(
+                f"email to: {practitioner.email_address}\n"
+                f"subject: {email_bits['subject']}\n"
+                f"body: {email_bits['text']}\n\n"
+                f"html: {email_bits['html']}\n\n"
+            )
+
 
 
 def assemble_unresponded_email(practitioner, patients):

--- a/isacc_messaging/api/email_notifications.py
+++ b/isacc_messaging/api/email_notifications.py
@@ -78,11 +78,8 @@ def assemble_outgoing_counts_email(practitioner, patients):
 
     subject = f"ISACC {len(patients)} Caring Contact sending today"
     contents = []
-    if primary:
-        contents.append(f"Caring Contact messages will be sent to {len(patients)} of your recipients today.")
-    if secondary:
-        contents.append(f"{len(primary)} of those contacts for whom you are the primary author,")
-        contents.append(f"{len(secondary)} of those contacts for whom you are the secondary author.")
+    contents.append(f"Today Caring Contact messages will be sent to {len(primary)} recipients for")
+    contents.append(f"whom you are the primary author, and {len(secondary)} for whom you are following.")
     msg = " ".join(contents)
     contents.append(f"Click here {patient_list_url} to view which of your recipients will be receiving a message.")
     contents.append("If you are not the person who should be getting these messages, contact your site lead.")
@@ -99,8 +96,6 @@ def assemble_outgoing_counts_email(practitioner, patients):
         "subject": subject,
         "text": " ".join(contents),
         "html": html}
-
-
 
 
 def generate_outgoing_counts_emails(dry_run, include_test_patients):

--- a/isacc_messaging/api/email_notifications.py
+++ b/isacc_messaging/api/email_notifications.py
@@ -103,10 +103,11 @@ def assemble_outgoing_counts_email(practitioner, patients):
 
 
 
-def generate_outgoing_counts_emails(dry_run):
+def generate_outgoing_counts_emails(dry_run, include_test_patients):
     """Generate system emails to practitioners with counts
 
     :param dry_run: set true to generate but not send email
+    :param include_test_patients: set true to include test patients
 
     At a scheduled time every day, this function will be triggered to generate email
     for every practitioner in the system, detailing the number of patients for which
@@ -128,6 +129,7 @@ def generate_outgoing_counts_emails(dry_run):
                 continue
 
             next_outgoing = p.get_extension(NEXT_OUTGOING_URL, attribute="valueDateTime")
+            logging.info(f"{p.id} {len(patients)}")
             if next_outgoing and next_outgoing.date > now and next_outgoing.date < cutoff:
                 keepers.add(p)
                 known_keepers.add(p)
@@ -139,7 +141,7 @@ def generate_outgoing_counts_emails(dry_run):
     practitioners = Practitioner.active_practitioners()
     for p in next_in_bundle(practitioners):
         practitioner = Practitioner(p)
-        practitioners_patients = practitioner.practitioner_patients()
+        practitioners_patients = practitioner.practitioner_patients(include_test_patients=include_test_patients)
         outgoing = outgoing_patients(practitioners_patients)
         if not outgoing:
             logging.debug(f"no qualifying outgoing patients for {practitioner}")
@@ -214,10 +216,11 @@ def assemble_unresponded_email(practitioner, patients):
         "html": html}
 
 
-def generate_unresponded_emails(dry_run):
+def generate_unresponded_emails(dry_run, include_test_patients):
     """Generate system emails to practitioners with counts
 
     :param dry_run: set true to generate but not send email
+    :param include_test_patients: set true to include test patients
 
     At a scheduled time every day, this function will be triggered to generate email
     for every practitioner in the system, detailing the number of patients for which
@@ -249,7 +252,7 @@ def generate_unresponded_emails(dry_run):
     practitioners = Practitioner.active_practitioners()
     for p in next_in_bundle(practitioners):
         practitioner = Practitioner(p)
-        practitioners_patients = practitioner.practitioner_patients()
+        practitioners_patients = practitioner.practitioner_patients(include_test_patients=include_test_patients)
         unresponded = unresponded_patients(practitioners_patients)
         if not unresponded:
             logging.debug(f"no qualifying unresponded patients for {practitioner}")

--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -181,9 +181,11 @@ def execute_requests():
 @click.argument("category", required=True)
 @click.option("--dry-run", is_flag=True, default=False, help="Simulate execution; generate but don't send email")
 def send_system_emails(category, dry_run):
-    from isacc_messaging.api.email_notifications import generate_unresponded_emails
+    from isacc_messaging.api.email_notifications import generate_outgoing_counts_emails, generate_unresponded_emails
     if category == 'unresponded':
         generate_unresponded_emails(dry_run)
+    elif category == 'outgoing':
+        generate_outgoing_counts_emails(dry_run)
     else:
         click.echo(f"unsupported category: {category}")
 

--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -180,12 +180,13 @@ def execute_requests():
 @base_blueprint.cli.command("send-system-emails")
 @click.argument("category", required=True)
 @click.option("--dry-run", is_flag=True, default=False, help="Simulate execution; generate but don't send email")
-def send_system_emails(category, dry_run):
+@click.option("--include-test-patients", is_flag=True, default=False, help="Include test patients")
+def send_system_emails(category, dry_run, include_test_patients):
     from isacc_messaging.api.email_notifications import generate_outgoing_counts_emails, generate_unresponded_emails
     if category == 'unresponded':
-        generate_unresponded_emails(dry_run)
+        generate_unresponded_emails(dry_run, include_test_patients)
     elif category == 'outgoing':
-        generate_outgoing_counts_emails(dry_run)
+        generate_outgoing_counts_emails(dry_run, include_test_patients)
     else:
         click.echo(f"unsupported category: {category}")
 

--- a/isacc_messaging/models/isacc_fhirdate.py
+++ b/isacc_messaging/models/isacc_fhirdate.py
@@ -12,6 +12,8 @@ class IsaccFHIRDate(FHIRDate):
         super(IsaccFHIRDate, self).__init__(jsonval=jsonval)
 
     def __gt__(self, other):
+        if not other:
+            raise TypeError(f"'>' not supported between instances of '{type(self)}' and '{type(other)}'")
         return self.date > other.date
 
     def __eq__(self, other):

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -157,6 +157,8 @@ class IsaccPatient(Patient):
         for c in next_in_bundle(Communication.about_patient(self)):
             # only consider outside communications reported to have been `sent`
             if "sent" in c:
+                if most_recent_followup is None:
+                    most_recent_followup = FHIRDate(c["sent"])
                 most_recent_followup = max(most_recent_followup, FHIRDate(c["sent"]))
                 break
 

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -186,6 +186,16 @@ class IsaccPatient(Patient):
                     level='debug'
                 )
 
+    def is_test_patient(self):
+        """Shortcut to see if meta.security list includes HTEST value"""
+        test_system = "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+        if not self.meta.security:
+            return
+
+        vals = [i.code for i in self.meta.security if i.system == test_system]
+        if vals and "HTEST" in vals:
+            return True
+
     def persist(self):
         """Persist self state to FHIR store"""
         response = HAPI_request(

--- a/isacc_messaging/models/isacc_practitioner.py
+++ b/isacc_messaging/models/isacc_practitioner.py
@@ -45,7 +45,7 @@ class IsaccPractitioner(Practitioner):
                     return t.value
         raise IsaccFhirException(f"Error: {self} doesn't have an sms contact point on file")
 
-    def practitioner_patients(self):
+    def practitioner_patients(self, include_test_patients=False):
         """Return bundle of patients for which this practitioner is a primary or secondary
 
         :returns: list of Patient objects
@@ -55,7 +55,10 @@ class IsaccPractitioner(Practitioner):
         for ct in next_in_bundle(careteams):
             # Each care team has one patient at subject/reference
             careteam = CareTeam(ct)
-            patients.append(resolve_reference(careteam.subject.reference))
+            patient = resolve_reference(careteam.subject.reference)
+            if not include_test_patients and patient.is_test_patient():
+                continue
+            patients.append(patient)
         return patients
 
     def persist(self):


### PR DESCRIPTION
Extending CLI `send-system-emails` with positional argument `outgoing`, to generate daily email to practitioners with counts of patient for whom they are the primary/secondary author, with an expected message delivery in the next 24 hours.

See spec: https://docs.google.com/document/d/1jDFFoO7nMQr_6qZIHicZr1rp_RcvK8wpn89IMDjiO24/edit