### PR TITLE
fix malformed html in notification email

### DIFF
--- a/isacc_messaging/api/email_notifications.py
+++ b/isacc_messaging/api/email_notifications.py
@@ -46,8 +46,8 @@ def send_message_received_notification(recipients: list, patient: Patient):
         link_url=link_url,
         link_suffix_text="to view it",
         post_link_msg=(
-            f'<a href="mailto:{SUPPORT_EMAIL}">Send Email</a>'
-            ' if you have questions.'),
+            "If you are not the person who should be getting these messages, contact "
+            f'<a href="mailto:{SUPPORT_EMAIL}">your site lead</a>.'),
         unsubscribe_link=UNSUB_LINK)
 
     send_email(

--- a/isacc_messaging/api/email_notifications.py
+++ b/isacc_messaging/api/email_notifications.py
@@ -46,8 +46,8 @@ def send_message_received_notification(recipients: list, patient: Patient):
         link_url=link_url,
         link_suffix_text="to view it",
         post_link_msg=(
-            f'<h3><a href="mailto:{SUPPORT_EMAIL}">Send Email</a>'
-            'if you have questions.</h3>'),
+            f'<a href="mailto:{SUPPORT_EMAIL}">Send Email</a>'
+            ' if you have questions.'),
         unsubscribe_link=UNSUB_LINK)
 
     send_email(


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2584667/stories/186482827

addressed malformed html in notification email:

- removed malformed html and replaced with footer content consistent with the other emails, e.g. [here](https://github.com/uwcirg/isacc-messaging-service/blob/3f64ed5510bd002459b8b8d528cae9fdf07b7ef0/isacc_messaging/api/email_notifications.py#L91)