### PR TITLE
Feature/fix communication request

### DIFF
--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -434,7 +434,7 @@ class IsaccRecordCreator:
             except Exception as e:
                 audit_entry(
                     "Failed to send the message",
-                    extra={"resource": f"CommunicationResource/{cr.id}", "exception": str(e)},
+                    extra={"resource": f"CommunicationResource/{cr.id}", "exception": e},
                     level='exception'
                 )
                 # Display Twilio Error in a human readable form

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -117,11 +117,10 @@ class IsaccRecordCreator:
             result = self.send_twilio_sms(message=expanded_payload, to_phone=target_phone)
 
         except TwilioRestException as ex:
-            for telecom_entry in patient.telecom:
-                if telecom_entry.system.lower() == "sms":
-                    # The error is raised when the user has unscubscribed 
-                    # mark this user as inactive for the future CRs
-                    telecom_entry.period.end = FHIRDate(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
+            # The error is raised when the user has unscubscribed 
+            # mark this user as inactive for the future CRs
+            sms_telecom_entry = next((entry for entry in patient.telecom if entry.system.lower() == 'sms'))
+            sms_telecom_entry.period.end = FHIRDate(datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
             patient.persist()
 
             audit_entry(

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import re
 from typing import List, Tuple
 
@@ -439,6 +439,7 @@ class IsaccRecordCreator:
                 telecom_entry.system.lower() == 'sms' and telecom_entry.period.end 
                 for telecom_entry in patient.telecom
             )
+            occurrence_utc = cr.occurrenceDateTime.date.replace(tzinfo=timezone.utc)
 
             if cr.occurrenceDateTime.date < cutoff:
                 # Anything older than cutoff will never be sent (#1861758)
@@ -447,7 +448,7 @@ class IsaccRecordCreator:
                 skipped_crs.append(cr)
                 continue
             if patient_unsubscribed:
-                if cr.occurrenceDateTime.date < now:
+                if occurrence_utc < datetime.now(timezone.utc):
                     # Skip the messages scheduled to send if user unsubscribed
                     skipped_crs.append(cr)
                 # Do not cancel future sms

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -384,7 +384,7 @@ class IsaccRecordCreator:
 
         message = values.get("Body")
         # if the user requested to resubscribe, mark him as active
-        if "start" in message.lower():
+        if "start" == message.lower():
             sms_telecom_entry = next((entry for entry in pt.telecom if entry.system.lower() == 'sms'))
             sms_telecom_entry.period.end = None
             pt.persist()

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -447,9 +447,10 @@ class IsaccRecordCreator:
                 skipped_crs.append(cr)
                 continue
             if patient_unsubscribed:
-                # Also, if the user already unscubscribed from messages, do not send
-                # no error should be raised
-                # Do not cancel, in case user resubscribes in time
+                if cr.occurrenceDateTime.date < now:
+                    # Skip the messages scheduled to send if user unsubscribed
+                    skipped_crs.append(cr)
+                # Do not cancel future sms
                 continue
             try:
                 self.process_cr(cr, successes)

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -440,13 +440,16 @@ class IsaccRecordCreator:
                 for telecom_entry in patient.telecom
             )
 
-            if cr.occurrenceDateTime.date < cutoff or patient_unsubscribed:
+            if cr.occurrenceDateTime.date < cutoff:
                 # Anything older than cutoff will never be sent (#1861758)
                 # and needs a status adjustment lest it throws off other queries
                 # like next outgoing message time
-                # Also, if the user has unscubscribed from messages, do not send
-                # no error should be raised
                 skipped_crs.append(cr)
+                continue
+            if patient_unsubscribed:
+                # Also, if the user already unscubscribed from messages, do not send
+                # no error should be raised
+                # Do not cancel, in case user resubscribes in time
                 continue
             try:
                 self.process_cr(cr, successes)

--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -1,6 +1,6 @@
 import click
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from flask import Blueprint, jsonify, request
 
 from isacc_messaging.api.isacc_record_creator import IsaccRecordCreator
@@ -220,20 +220,31 @@ def update_patient_active():
         )
 
 
-@base_blueprint.cli.command("maintenance-add-telecom-period-all-patients")
+@base_blueprint.cli.command("maintenance-add-telecom-period-start-all-patients")
 def update_patient_telecom():
     """Iterate through patients, add telecom start period to all of them"""
     from isacc_messaging.models.fhir import next_in_bundle
     from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
-    patients_without_telecom_period = Patient.custom_patients({"telecom:missing": "true"})
+    import fhirclient.models.period as period
+    from isacc_messaging.models.isacc_fhirdate import IsaccFHIRDate as FHIRDate
+    patients_without_telecom_period = Patient.all_patients()
+    new_period = period.Period()
+    # Get the current time in UTC
+    current_time = datetime.utcnow()
+    # Format the current time as per the required format
+    formatted_time = current_time.strftime('%Y-%m-%dT%H:%M:%SZ')
+    new_period.start = FHIRDate(formatted_time)
     for json_patient in next_in_bundle(patients_without_telecom_period):
         patient = Patient(json_patient)
-        patient.telecom.period.start = datetime.now(timezone.utc)
-        patient.persist()
-        audit_entry(
-        f"Patient {patient.id} active telecom period set to start now",
-        level='info'
-        )
+        if patient.telecom:
+            for telecom_entry in patient.telecom:
+                if telecom_entry.system.lower() == "sms" and not telecom_entry.period:
+                    telecom_entry.period = new_period
+                    patient.persist()
+                    audit_entry(
+                    f"Patient {patient.id} active telecom period set to start now",
+                    level='info'
+                    )
 
 
 @base_blueprint.cli.command("deactivate_patient")

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -29,15 +29,6 @@ class IsaccPatient(Patient):
         return f"{self.resource_type}/{self.id}"
 
     @staticmethod
-    def custom_patients(params):
-        """Execute custom query for all patients
-
-        NB, returns only patients that fit the params
-        """
-        response = HAPI_request('GET', 'Patient', params=params)
-        return response
-
-    @staticmethod
     def active_patients():
         """Execute query for active patients
 

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -29,6 +29,15 @@ class IsaccPatient(Patient):
         return f"{self.resource_type}/{self.id}"
 
     @staticmethod
+    def custom_patients(params):
+        """Execute custom query for all patients
+
+        NB, returns only patients that fit the params
+        """
+        response = HAPI_request('GET', 'Patient', params=params)
+        return response
+
+    @staticmethod
     def active_patients():
         """Execute query for active patients
 


### PR DESCRIPTION
Make current published CRs not be sent when the user decided to stop receiving Twilio SMS. Cancel the ones that were scheduled for time when the user would be not active as per https://www.pivotaltracker.com/n/projects/2584667