### PR TITLE
robustly handle failed callbacks from Twilio

### DIFF
--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -249,7 +249,7 @@ def retry_requests():
 
         # Only expecting one route at this time
         if (
-                failed_request.url.endswith("/NessageStatus") and
+                failed_request.url.endswith("/MessageStatus") and
                 failed_request.method.upper() == 'POST'):
             with current_app.test_request_context():
                 response, response_code = message_status_update(

--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -2,12 +2,16 @@ from functools import wraps
 import click
 import logging
 from datetime import datetime
+from time import sleep
 from flask import Blueprint, jsonify, request
 from flask import current_app
+from flask.cli import with_appcontext
+from twilio.request_validator import RequestValidator
 
 from isacc_messaging.api.isacc_record_creator import IsaccRecordCreator
 from isacc_messaging.audit import audit_entry
-from twilio.request_validator import RequestValidator
+from isacc_messaging.exceptions import IsaccTwilioSIDnotFound
+from isacc_messaging.robust_request import serialize_request, queue_request, pop_request
 
 base_blueprint = Blueprint('base', __name__, cli_group=None)
 
@@ -88,22 +92,43 @@ def auditlog_addevent():
 
 
 @base_blueprint.route("/MessageStatus", methods=['POST'])
-def message_status_update():
+def message_status_update(callback_req=None, attempt_count=0):
+    """Registered callback for Twilio to transmit updates
+
+    As Twilio occasionally hits this callback prior to local data being
+    available, it is also called subsequently from a job queue.  The
+    parameters are only defined in the retry state.
+
+    :param req: request from a job queue
+    :param attempt_count: the number of failed attemts thus far, only
+        defined from job queue
+    """
+    use_request = request
+    if callback_req:
+        use_request = callback_req
+
     audit_entry(
         f"Call to /MessageStatus webhook",
-        extra={'request.values': dict(request.values)},
+        extra={'use_request.values': dict(use_request.values)},
         level='debug'
     )
 
     record_creator = IsaccRecordCreator()
     try:
-        record_creator.on_twilio_message_status_update(request.values)
+        record_creator.on_twilio_message_status_update(use_request.values)
     except Exception as ex:
         audit_entry(
             f"on_twilio_message_status_update generated error {ex}",
             level='error'
         )
-        return ex, 200
+        # Couldn't locate the message, most likely means twilio was quicker
+        # to call back, than HAPI could persist and find.  Push to REDIS
+        # for another attempt later
+        if isinstance(ex, IsaccTwilioSIDnotFound):
+            req = serialize_request(use_request, attempt_count=attempt_count)
+            queue_request(req)
+
+        return str(ex), 200
     return '', 204
 
 
@@ -212,6 +237,25 @@ def execute_requests():
         f"Execution failed for CommunicationRequest resources:\n{error_list}"
     ])
 
+
+@base_blueprint.cli.command("retry_requests")
+@with_appcontext
+def retry_requests():
+    """Look for any failed requests and retry now"""
+    while True:
+        failed_request = pop_request()
+        if not failed_request:
+            break
+
+        # Only expecting one route at this time
+        if (
+                failed_request.url.endswith("/NessageStatus") and
+                failed_request.method.upper() == 'POST'):
+            with current_app.test_request_context():
+                response, response_code = message_status_update(
+                    failed_request, failed_request.attempt_count + 1)
+                if response_code != 204:
+                    sleep(1)  # give system a moment to catch up before retry
 
 @base_blueprint.cli.command("send-system-emails")
 @click.argument("category", required=True)

--- a/isacc_messaging/exceptions.py
+++ b/isacc_messaging/exceptions.py
@@ -1,0 +1,10 @@
+"""Module to define exceptions used by isacc_messaging."""
+
+class IsaccTwilioSIDnotFound(Exception):
+    """Raised when Twilio calls with SID that can't be found"""
+    pass
+
+
+class IsaccRequestRetriesExhausted(Exception):
+    """Raised when max retries have been tried w/o success"""
+    pass

--- a/isacc_messaging/robust_request.py
+++ b/isacc_messaging/robust_request.py
@@ -1,0 +1,44 @@
+"""Functions used for robust handling of failed requests
+
+Basic model: a request fails.  Rather than give up, push the request
+to a job queue and try again from a consumer.
+"""
+import json
+import redis
+from flask import current_app
+
+from isacc_messaging.exceptions import IsaccRequestRetriesExhausted
+
+
+def serialize_request(req, attempt_count=1, max_retries=3):
+    """Given a request object, returns a serialized form
+
+    :param req: The request object
+    :param attempt_count: Increment from previous failure on each call
+    :param max_retries: Maximum number of retries before giving up
+
+    Need a serialized form of the request to push into a job queue.
+    This also maintains and enforces the number of attempts doesn't
+    exceed the maximum.
+    """
+    serialized_form = json.dumps({
+        "method": req.method,
+        "url": req.url,
+        "headers": dict(req.headers),
+        "body": req.get_data(as_text=True),
+        "attempt_count": attempt_count,
+        "max_retries": max_retries
+    })
+    if attempt_count > max_retries:
+        raise IsaccRequestRetriesExhausted(serialized_form)
+    return serialized_form
+
+def queue_request(serialized_request):
+    redis_client = redis.StrictRedis.from_url(current_app.config.get("REQUEST_CACHE_URL"))
+    redis_client.lpush("http_request_queue", serialized_request)
+
+
+def pop_request():
+    redis_client = redis.StrictRedis.from_url(current_app.config.get("REQUEST_CACHE_URL"))
+    return redis_client.rpop("http_request_queue")
+


### PR DESCRIPTION
Tracing logs suggests we might be failing to locate a Communication with a matching SID, as Twilio called back with a status update on the message prior to the Communication being available for query.

This PR introduces a failed request / call back mechanism, by catching the exception and pushing the request into a named queue in redis.

We'll need to call the `retry_requests` CLI frequently from cron, prior to `execute_requests` as is done now.