### PR TITLE
consider mark-resolved when determining time since follow up

### DIFF
--- a/isacc_messaging/models/isacc_communication.py
+++ b/isacc_messaging/models/isacc_communication.py
@@ -39,12 +39,15 @@ class IsaccCommunication(Communication):
     def about_patient(patient):
         """Query for "outside" Communications about the patient
 
+        This includes the dummy Communications added when staff resolve
+        a message without a response (category:isacc-message-resolved-no-send)
+
         NB: only `sent` or `received` will have a valueDateTime depending on
         direction of outside communication.  `sent` implies communication from
         practitioner, `received` implies communication from patient.
         """
         return HAPI_request("GET", "Communication", params={
-            "category": "isacc-non-sms-message",
+            "category": "isacc-non-sms-message,isacc-message-resolved-no-send",
             "subject": f"Patient/{patient.id}",
             "_sort": "-sent",
         })

--- a/isacc_messaging/models/isacc_patient.py
+++ b/isacc_messaging/models/isacc_patient.py
@@ -235,7 +235,7 @@ class IsaccPatient(Patient):
         for c in next_in_bundle(Communication.for_patient(self, category="isacc-manually-sent-message")):
             most_recent_followup = FHIRDate(c["sent"])
             break
-        # also possible a followup was recorded as `outside communication`
+        # also possible a followup was recorded as `outside communication` or resolved
         for c in next_in_bundle(Communication.about_patient(self)):
             # only consider outside communications reported to have been `sent`
             if "sent" in c:


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2584667/stories/188624366

look for Communication category `isacc-message-resolved-no-send` when looking up un-followed-up message times.  this will catch the faux Communication marker added when user selects to [MARK MESSAGE AS READ/RESOLVED], and thus accurately calculate `time-of-last-unfollowedup-message`