### PR TITLE
adjust user's next-outgoing extension AFTER communication request status change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ ENV FLASK_APP=isacc_messaging.app:create_app() \
 
 EXPOSE "${PORT}"
 
-CMD gunicorn --bind "0.0.0.0:${PORT:-8000}" ${FLASK_APP}
+CMD flask upgrade && gunicorn --bind "0.0.0.0:${PORT:-8000}" ${FLASK_APP}

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -348,11 +348,9 @@ class IsaccRecordCreator:
             if not patient.active or cr.occurrenceDateTime.date < cutoff:
                 cr.status = "revoked"
                 cr.persist()
-                revoked_reason = ""
+                revoked_reason = "Past the cutoff"
                 if not patient.active:
                     revoked_reason = "Recipient is not active"
-                else:
-                    revoked_reason = "Past the cutoff"
                 cr.report_cr_status(status_reason=revoked_reason)
                 errors.append({'id': cr.id, 'error': revoked_reason})
                 patient.mark_next_outgoing()  # update given state change

--- a/isacc_messaging/api/isacc_record_creator.py
+++ b/isacc_messaging/api/isacc_record_creator.py
@@ -342,10 +342,7 @@ class IsaccRecordCreator:
         sent = 0
         for cr_json in next_in_bundle(result):
             cr = CommunicationRequest(cr_json)
-            # as that message was likely the next-outgoing for the patient,
-            # update the extension used to track next-outgoing-message time
             patient = resolve_reference(cr.recipient[0].reference)
-            patient.mark_next_outgoing()
 
             # Do not interact with CR if the patient is inactive or sending date is past the cutoff
             if not patient.active or cr.occurrenceDateTime.date < cutoff:
@@ -358,6 +355,7 @@ class IsaccRecordCreator:
                     revoked_reason = "Past the cutoff"
                 cr.report_cr_status(status_reason=revoked_reason)
                 errors.append({'id': cr.id, 'error': revoked_reason})
+                patient.mark_next_outgoing()  # update given state change
                 continue
 
             # Otherwise, create a communication
@@ -384,6 +382,7 @@ class IsaccRecordCreator:
                     extra={"Updated Communication": stopped_comm},
                     level='debug'
                 )
+                patient.mark_next_outgoing()  # update given state change
                 continue
 
             # Otherwise, update according to the feedback from the dispatch
@@ -419,6 +418,7 @@ class IsaccRecordCreator:
                     extra={"resource": f"Communication/{comm.id}", "statusReason": e},
                     level='exception'
                 )
+            patient.mark_next_outgoing()  # update given state change
 
             # Flooding system on occasions such as a holiday message to all,
             # leads to an overwhelmed system.  Restrict the flood by processing

--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -275,18 +275,19 @@ def send_system_emails(category, dry_run, include_test_patients):
 @click.option("--dry-run", is_flag=True, default=False, help="Simulate execution; don't persist to FHIR store")
 def update_patient_extensions(dry_run):
     """Iterate through active patients, update any stale/missing extensions"""
-    # this was a 1 and done migration method.  disable for now
-    raise click.ClickException(
-        "DISABLED: unsafe to run as this will now undo any user marked "
-        "read messages via "
-        "https://github.com/uwcirg/isacc-messaging-client-sof/pull/85")
+    # not routinely used - typically following a bug fix WRT user extensions
+
+    # NB - no longer updating the followup-extension as it would displace
+    # any work done by users who "marked as read" the latest message for a patient
+    # see https://github.com/uwcirg/isacc-messaging-client-sof/pull/85
+
     from isacc_messaging.models.fhir import next_in_bundle
     from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
     active_patients = Patient.active_patients()
     for json_patient in next_in_bundle(active_patients):
         patient = Patient(json_patient)
         patient.mark_next_outgoing(persist_on_change=not dry_run)
-        patient.mark_followup_extension(persist_on_change=not dry_run)
+        # (see note above) patient.mark_followup_extension(persist_on_change=not dry_run)
 
 
 @base_blueprint.cli.command("maintenance-reinstate-all-patients")

--- a/isacc_messaging/api/views.py
+++ b/isacc_messaging/api/views.py
@@ -275,19 +275,18 @@ def send_system_emails(category, dry_run, include_test_patients):
 @click.option("--dry-run", is_flag=True, default=False, help="Simulate execution; don't persist to FHIR store")
 def update_patient_extensions(dry_run):
     """Iterate through active patients, update any stale/missing extensions"""
-    # not routinely used - typically following a bug fix WRT user extensions
-
-    # NB - no longer updating the followup-extension as it would displace
-    # any work done by users who "marked as read" the latest message for a patient
-    # see https://github.com/uwcirg/isacc-messaging-client-sof/pull/85
-
+    # this was a 1 and done migration method.  disable for now
+    raise click.ClickException(
+        "DISABLED: unsafe to run as this will now undo any user marked "
+        "read messages via "
+        "https://github.com/uwcirg/isacc-messaging-client-sof/pull/85")
     from isacc_messaging.models.fhir import next_in_bundle
     from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
     active_patients = Patient.active_patients()
     for json_patient in next_in_bundle(active_patients):
         patient = Patient(json_patient)
         patient.mark_next_outgoing(persist_on_change=not dry_run)
-        # (see note above) patient.mark_followup_extension(persist_on_change=not dry_run)
+        patient.mark_followup_extension(persist_on_change=not dry_run)
 
 
 @base_blueprint.cli.command("maintenance-reinstate-all-patients")

--- a/migrations/versions/recalculate-next-outgoing-times.py
+++ b/migrations/versions/recalculate-next-outgoing-times.py
@@ -1,0 +1,24 @@
+# Migration script generated for recalculate-next-outgoing-times
+revision = '17f3b60d-0777-4d0e-bb32-82e670b573a7'
+down_revision = 'None'
+
+import logging
+from isacc_messaging.models.fhir import next_in_bundle
+from isacc_messaging.models.isacc_patient import IsaccPatient as Patient
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+
+def upgrade():
+    # iterate over active patients; confirm/set next-outgoing extension
+    active_patients = Patient.active_patients()
+    for json_patient in next_in_bundle(active_patients):
+        patient = Patient(json_patient)
+        patient.mark_next_outgoing(persist_on_change=True)
+    logging.info('corrected next-outgoing-times')
+
+
+def downgrade():
+    # Nothing to undo
+    logging.info('downgraded')
+


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/n/projects/2584667/stories/188742640

next-outgoing was incorrect after message send.
the code order was in error - the attempt to update the user's extension for "date-time-of-next-outgoing-message" happened prior to the communication request status change on message send.

This PR depends on https://github.com/uwcirg/isacc-environments/pull/40 (or the migrations won't run correctly)